### PR TITLE
Fix preinstall issue on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,11 @@ function consumeSnippets({load} => {
 
 Install
 -------
-`apm install modular-snippets` or search “snippets” under packages within Atom.
+1. Windows only! If on another OS, use the original package [here](https://github.com/danielbayley/atom-modular-snippets)
+2. Make sure you have GIT installed
+3. ATOM_HOME environment variable defined as the location of your .atom folder
+    - If default atom install, run `set ATOM_HOME=%USERPROFILE%\.atom` from cmd
+4. Install package from github: `apm install bigcat2014/atom-modular-snippets`
 
 License
 -------

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "require-cson": "^0.1.0"
   },
   "scripts": {
-    "preinstall": "mkdir -p \"${ATOM_HOME:-$HOME/.atom}\"/snippets"
+    "preinstall": "mkdir \"%ATOM_HOME%\snippets\""
   },
   "engines": {
     "atom": "*"


### PR DESCRIPTION
Change the path in the preintstall portion of the package.json file so that it works on Windows.